### PR TITLE
Use protocol-relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
 
 <title>Foundation 4</title>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 
 
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" href="static/foundation-5.0.2/css/foundation.css">
 <script src="static/foundation-5.0.2/js/vendor/custom.modernizr.js"></script>


### PR DESCRIPTION
When loaded from https://github.io... jquery does not load.

Protocol-relative paths take the protocol of the parent page to allow loading over http or https.